### PR TITLE
Sửa deploy GitHub Pages — billing + hướng dẫn deploy từ branch

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,28 +1,21 @@
-# Simple workflow for deploying static content to GitHub Pages
+# Deploy static overlay lên GitHub Pages
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -31,13 +24,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: |
+            index.html
+            css
+            js
+            image
+            .nojekyll
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,33 @@
+# Hướng dẫn deploy overlay
+
+URL sau khi deploy: **https://pudo58.github.io/livestream_frame/**
+
+## Lỗi thường gặp: Actions không chạy (billing)
+
+Nếu workflow báo:
+
+> *The job was not started because your account is locked due to a billing issue.*
+
+Đây **không phải lỗi code** — tài khoản GitHub bị khóa do vấn đề thanh toán / hết quota Actions.
+
+### Cách 1 — Sửa billing (để dùng lại Actions)
+
+1. Vào https://github.com/settings/billing
+2. Kiểm tra thẻ thanh toán, hạn mức spending, hoặc gói GitHub
+3. Sau khi xử lý xong, vào **Actions** → chọn workflow **Deploy static content to Pages** → **Re-run all jobs**
+
+### Cách 2 — Deploy từ branch (không cần Actions, miễn phí)
+
+1. Vào repo → **Settings** → **Pages**
+2. **Build and deployment** → Source: chọn **Deploy from a branch**
+3. Branch: **main**, Folder: **/ (root)**
+4. Save — GitHub sẽ tự publish mỗi lần push lên `main`
+
+File `.nojekyll` trong repo giúp GitHub serve file tĩnh đúng cách (không qua Jekyll).
+
+## Dùng overlay trong OBS
+
+1. Mở URL Pages trong trình duyệt để kiểm tra
+2. OBS → **Sources** → **Browser**
+3. URL: `https://pudo58.github.io/livestream_frame/`
+4. Width: **1920**, Height: **1080**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Nguyên nhân lỗi deploy

Workflow **Deploy static content to Pages** fail sau merge PR #8 với thông báo:

> *The job was not started because your account is locked due to a billing issue.*

Đây là lỗi **billing GitHub Actions**, không phải lỗi code overlay. Job không hề chạy (fail sau ~5 giây).

## Thay đổi trong PR

- Thêm `.nojekyll` — hỗ trợ deploy tĩnh từ branch
- Workflow chỉ upload file cần thiết (`index.html`, `css/`, `js/`, `image/`)
- Thêm `DEPLOY.md` hướng dẫn xử lý

## Cách khắc phục (chọn 1)

### Cách 1 — Sửa billing
1. https://github.com/settings/billing
2. Xử lý thẻ / hạn mức / gói GitHub
3. Re-run workflow trong tab Actions

### Cách 2 — Deploy từ branch (không cần Actions)
1. Repo → **Settings** → **Pages**
2. Source: **Deploy from a branch**
3. Branch: **main**, Folder: **/ (root)**
4. Save → site tự publish khi push `main`

URL: https://pudo58.github.io/livestream_frame/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b9a1dba-896a-443a-9c31-9ac01d0de25b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b9a1dba-896a-443a-9c31-9ac01d0de25b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

